### PR TITLE
A few small tweaks to fix problems in the latest Chrome and Brave builds (breakfix + cosmetic)

### DIFF
--- a/background.js
+++ b/background.js
@@ -91,7 +91,7 @@ chrome.runtime.onMessage.addListener (function(request, sender, sendResponse)
 						 action: 'version',
 				 signature: settings.signature,
 					 },
-				 '^.*<version>(\\d+\\.\\d+.*)<\\/version>.*$'
+				 '.*<version>(\\d+\\.\\d+.*)<\\/version>.*'
 		).then(function(result) {
 			chrome.storage.local.set(settings, function (){
 				sendResponse (result);});

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
 	"manifest_version": 2,
 	"name": "YOURLS",
 	"short_name": "YOURLS",
-	"version": "2.1.2",
+	"version": "2.1.3",
 	"author": "Martin Scharm <https://binfalse.de/contact/>",
 	"description": "Shorten URLs with your own YOURLS instance",
 	"icons":

--- a/popup.css
+++ b/popup.css
@@ -1,6 +1,6 @@
 body {
 	padding: 20px;
-	min-width: 400px;
+	min-width: 450px;
 }
 .display_table {
 	width: 100%;


### PR DESCRIPTION
The regex engine in Chrome changed recently, which caused the version validation code to break, which prevented the extension from being configured and used (I really don't understand _why_ it broke - the regex was technically valid, but it refused to work). Also, the CSS for the options popup was causing an obnoxious flashing/strobing problem where the window would resize itself multiple times a second, caused by Chrome trying to add horizontal scrollbar, which caused a vertical scrollbar to appear, which caused the horizontal to disappear. 

Sorry for the multiple commits; wasn't really thinking this all the way through when I started. Please squash. :)